### PR TITLE
Add all border-style values

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,20 @@ npm install border.css
 
 ### [`border-style`](border-style.css)
 - `.border-none`
-- `.border-top-none`
-- `.border-left-none`
-- `.border-right-none`
-- `.border-bottom-none`
+  - `.border-top-none`
+  - `.border-left-none`
+  - `.border-right-none`
+  - `.border-bottom-none`
+- `.border-solid`
+- `.border-dotted`
+- `.border-dashed`
+- `.border-double`
+- `.border-groove`
+- `.border-ridge`
+- `.border-inset`
+- `.border-outset`
+- `.border-hidden`
+
 
 ### [`border-width`](border-width.css)
 - `.border-zero`

--- a/border-style.css
+++ b/border-style.css
@@ -1,4 +1,14 @@
 .border-none { border-style: none }
+.border-solid { border-style: solid }
+.border-dotted { border-style: dotted }
+.border-dashed { border-style: dashed }
+.border-double { border-style: double }
+.border-groove { border-style: groove }
+.border-ridge { border-style: ridge }
+.border-inset { border-style: inset }
+.border-outset { border-style: outset }
+.border-hidden { border-style: hidden }
+
 .border-top-none { border-top-style: none }
 .border-left-none { border-left-style: none }
 .border-right-none { border-right-style: none }

--- a/border.css
+++ b/border.css
@@ -5,6 +5,16 @@
 .border-transparent { border-color: transparent }
 
 .border-none { border-style: none }
+.border-solid { border-style: solid }
+.border-dotted { border-style: dotted }
+.border-dashed { border-style: dashed }
+.border-double { border-style: double }
+.border-groove { border-style: groove }
+.border-ridge { border-style: ridge }
+.border-inset { border-style: inset }
+.border-outset { border-style: outset }
+.border-hidden { border-style: hidden }
+
 .border-top-none { border-top-style: none }
 .border-left-none { border-left-style: none }
 .border-right-none { border-right-style: none }


### PR DESCRIPTION
I put `hidden` last to overrides all the others. Conceptually this is like how `hidden` takes precendence during border collapsing [as described on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style). `none` has lowest precendence for collapsing. `hidden` has highest.