### PR TITLE
Order border-style classes to match border conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,15 @@ npm install border.css
   - `.border-left-none`
   - `.border-right-none`
   - `.border-bottom-none`
-- `.border-solid`
+- `.border-inset`
+- `.border-groove`
+- `.border-outset`
+- `.border-ridge`
 - `.border-dotted`
 - `.border-dashed`
+- `.border-solid`
 - `.border-double`
-- `.border-groove`
-- `.border-ridge`
-- `.border-inset`
-- `.border-outset`
 - `.border-hidden`
-
 
 ### [`border-width`](border-width.css)
 - `.border-zero`

--- a/border-style.css
+++ b/border-style.css
@@ -1,12 +1,12 @@
 .border-none { border-style: none }
-.border-solid { border-style: solid }
+.border-inset { border-style: inset }
+.border-groove { border-style: groove }
+.border-outset { border-style: outset }
+.border-ridge { border-style: ridge }
 .border-dotted { border-style: dotted }
 .border-dashed { border-style: dashed }
+.border-solid { border-style: solid }
 .border-double { border-style: double }
-.border-groove { border-style: groove }
-.border-ridge { border-style: ridge }
-.border-inset { border-style: inset }
-.border-outset { border-style: outset }
 .border-hidden { border-style: hidden }
 
 .border-top-none { border-top-style: none }

--- a/border.css
+++ b/border.css
@@ -5,14 +5,14 @@
 .border-transparent { border-color: transparent }
 
 .border-none { border-style: none }
-.border-solid { border-style: solid }
+.border-inset { border-style: inset }
+.border-groove { border-style: groove }
+.border-outset { border-style: outset }
+.border-ridge { border-style: ridge }
 .border-dotted { border-style: dotted }
 .border-dashed { border-style: dashed }
+.border-solid { border-style: solid }
 .border-double { border-style: double }
-.border-groove { border-style: groove }
-.border-ridge { border-style: ridge }
-.border-inset { border-style: inset }
-.border-outset { border-style: outset }
 .border-hidden { border-style: hidden }
 
 .border-top-none { border-top-style: none }


### PR DESCRIPTION
### [border conflict resolution](https://www.w3.org/TR/CSS2/tables.html#border-conflict-resolution)

> Borders with the `border-style` of `hidden` take precedence over all other conflicting borders. Any border with this value suppresses all borders at this location.

> Borders with a style of `none` have the lowest priority. Only if the border properties of all the elements meeting at this edge are 'none' will the border be omitted (but note that 'none' is the default value for the border style.)

> If none of the styles are `hidden` and at least one of them is not 'none', then narrow borders are discarded in favor of wider ones. If several have the same 'border-width' then styles are preferred in this order: `double`, `solid`, `dashed`, `dotted`, `ridge`, `outset`, `groove`, and the lowest: `inset`.

> If border styles differ only in color, then a style set on a cell wins over one on a row, which wins over a row group, column, column group and, lastly, table. When two elements of the same type conflict, then the one further to the left (if the table's `direction` is `ltr`; right, if it is `rtl`) and further to the top wins.