### PR TITLE
Use terser classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ npm install border.css
 
 ### [`border-style`](border-style.css)
 - `.border-none`
-  - `.border-top-none`
-  - `.border-left-none`
-  - `.border-right-none`
-  - `.border-bottom-none`
+  - `.top-none`
+  - `.left-none`
+  - `.right-none`
+  - `.bottom-none`
 - `.border-inset`
 - `.border-groove`
 - `.border-outset`
@@ -45,17 +45,17 @@ npm install border.css
 - `.border-solid`
 - `.border-double`
 - `.border-hidden`
-  - `.border-top-hidden`
-  - `.border-left-hidden`
-  - `.border-right-hidden`
-  - `.border-bottom-hidden`
+  - `.top-hidden`
+  - `.left-hidden`
+  - `.right-hidden`
+  - `.bottom-hidden`
 
 ### [`border-width`](border-width.css)
 - `.border-zero`
-  - `.border-top-zero`
-  - `.border-left-zero`
-  - `.border-right-zero`
-  - `.border-bottom-zero`
+  - `.top-zero`
+  - `.left-zero`
+  - `.right-zero`
+  - `.bottom-zero`
 - `.border-thin`
 - `.border-medium`
 - `.border-thick`

--- a/border-style.css
+++ b/border-style.css
@@ -9,12 +9,12 @@
 .border-double { border-style: double }
 .border-hidden { border-style: hidden }
 
-.border-top-none { border-top-style: none }
-.border-left-none { border-left-style: none }
-.border-right-none { border-right-style: none }
-.border-bottom-none { border-bottom-style: none }
+.top-none { border-top-style: none }
+.left-none { border-left-style: none }
+.right-none { border-right-style: none }
+.bottom-none { border-bottom-style: none }
 
-.border-top-hidden { border-top-style: hidden }
-.border-left-hidden { border-left-style: hidden }
-.border-right-hidden { border-right-style: hidden }
-.border-bottom-hidden { border-bottom-style: hidden }
+.top-hidden { border-top-style: hidden }
+.left-hidden { border-left-style: hidden }
+.right-hidden { border-right-style: hidden }
+.bottom-hidden { border-bottom-style: hidden }

--- a/border-width.css
+++ b/border-width.css
@@ -3,7 +3,7 @@
 .border-medium { border-width: medium }
 .border-thick { border-width: thick }
 
-.border-top-zero { border-top-width: 0 }
-.border-left-zero { border-left-width: 0 }
-.border-right-zero { border-right-width: 0 }
-.border-bottom-zero { border-bottom-width: 0 }
+.top-zero { border-top-width: 0 }
+.left-zero { border-left-width: 0 }
+.right-zero { border-right-width: 0 }
+.bottom-zero { border-bottom-width: 0 }

--- a/border.css
+++ b/border.css
@@ -15,22 +15,22 @@
 .border-double { border-style: double }
 .border-hidden { border-style: hidden }
 
-.border-top-none { border-top-style: none }
-.border-left-none { border-left-style: none }
-.border-right-none { border-right-style: none }
-.border-bottom-none { border-bottom-style: none }
+.top-none { border-top-style: none }
+.left-none { border-left-style: none }
+.right-none { border-right-style: none }
+.bottom-none { border-bottom-style: none }
 
-.border-top-hidden { border-top-style: hidden }
-.border-left-hidden { border-left-style: hidden }
-.border-right-hidden { border-right-style: hidden }
-.border-bottom-hidden { border-bottom-style: hidden }
+.top-hidden { border-top-style: hidden }
+.left-hidden { border-left-style: hidden }
+.right-hidden { border-right-style: hidden }
+.bottom-hidden { border-bottom-style: hidden }
 
 .border-zero { border-width: 0 }
 .border-thin { border-width: thin }
 .border-medium { border-width: medium }
 .border-thick { border-width: thick }
 
-.border-top-zero { border-top-width: 0 }
-.border-left-zero { border-left-width: 0 }
-.border-right-zero { border-right-width: 0 }
-.border-bottom-zero { border-bottom-width: 0 }
+.top-zero { border-top-width: 0 }
+.left-zero { border-left-width: 0 }
+.right-zero { border-right-width: 0 }
+.bottom-zero { border-bottom-width: 0 }


### PR DESCRIPTION
WDYT? This simpler naming seems friendlier to me the absolute explicitness it was before. These seem reasonably  intuitive and learnable. `border-style` values that have no meaning on the [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) `top` `left` `right` `bottom` sides. These could compose safely with [edge.css](https://github.com/ryanve/edge.css/blob/v0.3.0/edge.css) for example.